### PR TITLE
show only latest push by default

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  CheckboxItem,
   DropdownMenuRadioItem,
   ItemIndicator,
 } from "@radix-ui/react-dropdown-menu";
@@ -140,12 +141,16 @@ function Row({
 
 function Rows() {
   const [value, setValue] = useState("all");
+  const [latestOnly, setLatestOnly] = useState(true);
+  const displayLatestOnly = latestOnly && value === "all";
   const [gitShaToCheck, setGitShaToCheck] = useState("");
   const serviceToLastPushed = useQuery(api.version_history.services) || [];
   const messages =
     useQuery(api.version_history.list, {
       service: value === "all" ? undefined : value,
     }) || [];
+  const latestPushes = useQuery(api.version_history.listLatest) || [];
+  const pushes = displayLatestOnly ? latestPushes : messages;
 
   const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = (
     event
@@ -206,6 +211,16 @@ function Rows() {
             </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenu>
+        {
+          value === "all" && <div>
+            <Input
+              type="checkbox"
+              checked={latestOnly}
+              onChange={(e) => setLatestOnly(e.target.checked)}
+            />
+            Latest only
+          </div>
+        }
         <Input
           className="max-w-56"
           onChange={handleInputChange}
@@ -222,7 +237,7 @@ function Rows() {
       )}
       <div>🥱 - It's been over a week</div>
       <div className="flex flex-col p-4 divide-y gap-2">
-        {messages.map((message) => (
+        {pushes.map((message) => (
           <Row
             key={JSON.stringify(message)}
             message={message}


### PR DESCRIPTION
currently, I have to scroll to see when we last pushed funrun, and double check when i find it that i didn't miss a more recent push:

![Screenshot 2024-08-14 at 12 32 54 PM](https://github.com/user-attachments/assets/e7f1e864-a69a-4171-826c-65111cf0964a)

with this PR, by default we only display the latest pushed version of each service.
both views are useful, but I think by default when I go to isitout I want to see the currently pushed version for each service, and i don't mind an extra step (unchecking the box) to view previous versions.

![Screenshot 2024-08-14 at 12 32 46 PM](https://github.com/user-attachments/assets/b1d563ac-1d35-4c19-ac25-1f369a8e6716)
