### PR TITLE
fix diff previous

### DIFF
--- a/convex/version_history.ts
+++ b/convex/version_history.ts
@@ -112,6 +112,7 @@ export const prevRev = query({
       .withIndex("by_service", (q) =>
         q.eq("service", args.service).lt("_creationTime", args._creationTime)
       )
+      .order("desc")
       .first();
   },
 });


### PR DESCRIPTION
currently the "diff previous" button diffs the current rev against the first rev, instead of diffing against the previous rev