### PR TITLE
Add is_stable column to versions view and local dev setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,34 @@
 
 Is it out is an app built on Convex and used by Convex engineers to see the version
 history of each of our internal services.
+
+## Local Development Setup
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+
+2. **Set up Convex**
+   ```bash
+   npx convex dev
+   ```
+   This creates a new development deployment. Copy all environment variables from the production `isitout` deployment in the [Convex team dashboard](https://dashboard.convex.dev).
+
+3. **Configure Google OAuth**
+   - Go to [Google Cloud Console - Credentials](https://console.cloud.google.com/auth/clients)
+   - Create a new OAuth 2.0 Client ID (Web application)
+   - Set **Authorized JavaScript origins** to: `http://localhost:5173`
+   - Set **Authorized redirect URI** to: `https://<your-deployment>.convex.site/api/auth/callback/google`
+
+   (Find your deployment name in `.env.local` under `CONVEX_DEPLOYMENT`)
+
+4. **Set environment variables in Convex dashboard**
+   - `AUTH_GOOGLE_ID` — your Google Client ID
+   - `AUTH_GOOGLE_SECRET` — your Google Client Secret
+   - `SITE_URL` — `http://localhost:5173`
+
+5. **Run the app**
+   ```bash
+   npm run dev
+   ```

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,7 +1,23 @@
 import { httpRouter } from "convex/server";
 import { auth } from "./auth";
+import { httpAction } from "./_generated/server";
+import { api } from "./_generated/api";
 
 const http = httpRouter();
+
+http.route({
+  path: "/latest-stable-biz-version",
+  method: "GET",
+  handler: httpAction(async (ctx, request) => {
+    const { service } = await request.json();
+    const version = await ctx.runQuery(
+      api.version_history.latestStableReleaseForBiz,
+      { service }
+    );
+
+    return new Response(JSON.stringify({ service, version }), { status: 200 });
+  }),
+});
 
 auth.addHttpRoutes(http);
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,7 +7,11 @@ export default defineSchema({
   version_history: defineTable({
     service: v.string(),
     version: v.string(),
-  }).index("by_service", ["service"]),
+    is_stable: v.optional(v.boolean()),
+  })
+    .index("by_service", ["service"])
+    .index("by_service_and_is_stable", ["service", "is_stable"])
+    .index("by_service_and_version", ["service", "version"]),
   last_sync: defineTable({
     time: v.float64(),
   }),


### PR DESCRIPTION
## Summary
- Add checkbox to toggle release stability in the versions list
- Default is_stable to true for releases without the field set
- Add markReleaseStability mutation with auth verification
- Add Local Development Setup section to README with Google OAuth instructions

## Test plan
- [x] Verify checkbox displays correctly for each version row
- [x] Test toggling stability on/off updates the database
- [x] Confirm auth check prevents unauthorized users from toggling
- [x] Follow README setup instructions on a fresh clone

Screenshot of new UI
<img width="1848" height="820" alt="Screenshot 2026-01-16 at 3 20 34 PM" src="https://github.com/user-attachments/assets/1c3d7591-6550-4e07-8a5a-07350a4f6292" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)