### PR TITLE
Add stable column tooltip + fix HTTP endpoint to use query params

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -9,12 +9,25 @@ http.route({
   path: "/latest-stable-biz-version",
   method: "GET",
   handler: httpAction(async (ctx, request) => {
-    const { service } = await request.json();
+    const url = new URL(request.url);
+    const service = url.searchParams.get("service");
+    if (!service) {
+      return new Response(JSON.stringify({ error: "Service is required" }), {
+        status: 400,
+      });
+    }
     const version = await ctx.runQuery(
       api.version_history.latestStableReleaseForBiz,
       { service }
     );
-
+    if (!version) {
+      return new Response(
+        JSON.stringify({
+          error: "No stable version found for service " + service,
+        }),
+        { status: 404 }
+      );
+    }
     return new Response(JSON.stringify({ service, version }), { status: 200 });
   }),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import {
 } from "@radix-ui/react-dropdown-menu";
 import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
-import { CheckIcon } from "@radix-ui/react-icons";
+import { CheckIcon, InfoCircledIcon } from "@radix-ui/react-icons";
 import {
   Tooltip,
   TooltipContent,
@@ -260,7 +260,19 @@ function Rows() {
           <div className="w-[45%]">Version</div>
           <div className="w-[15%]">Service</div>
           <div className="w-[20%]">Pushed</div>
-          <div className="w-[10%] text-center">Stable</div>
+          <div className="w-[10%] flex items-center justify-center gap-1">
+            <span>Stable</span>
+            <TooltipProvider delayDuration={0}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <InfoCircledIcon className="h-4 w-4 text-gray-400 hover:text-gray-600" />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  <p>Versions default to stable and can be manually marked as unstable if there is a bug.</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
         </div>
         {pushes.map((message) => (
           <Row


### PR DESCRIPTION
## Summary
- Add info icon tooltip to Stable column header explaining the feature
- Change `/latest-stable-biz-version` endpoint to read `service` from URL query params instead of request body (GET requests don't reliably carry bodies)
- Add proper error responses for missing service (400) and version not found (404)

## Test plan
- [x] Test endpoint with `curl "https://.../latest-stable-biz-version?service=funrun"`
- [x] Verify tooltip appears on hover over the info icon next to "Stable" column header

New tooltip:
<img width="382" height="456" alt="Screenshot 2026-01-16 at 4 58 39 PM" src="https://github.com/user-attachments/assets/5e48b339-7a12-41fa-ab63-b445df19166a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)