### PR TITLE
Add release tag support for tracking multiple release channels

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,11 +7,17 @@ export default defineSchema({
   version_history: defineTable({
     service: v.string(),
     version: v.string(),
+    release_tag: v.optional(v.string()),
     is_stable: v.optional(v.boolean()),
   })
     .index("by_service", ["service"])
-    .index("by_service_and_is_stable", ["service", "is_stable"])
-    .index("by_service_and_version", ["service", "version"]),
+    .index("by_service_and_version", ["service", "version"])
+    .index("by_service_and_release_tag", ["service", "release_tag"])
+    .index("by_service_release_tag_and_is_stable", [
+      "service",
+      "release_tag",
+      "is_stable",
+    ]),
   last_sync: defineTable({
     time: v.float64(),
   }),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,20 @@ function Ago({ d }: { d: Date }) {
   );
 }
 
+function ReleaseTagBadge({ tag }: { tag: string }) {
+  const colorClasses: Record<string, string> = {
+    default: "bg-blue-100 text-blue-800",
+    biz: "bg-green-100 text-green-800",
+  };
+  const classes = colorClasses[tag] ?? "bg-gray-100 text-gray-800";
+
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${classes}`}>
+      {tag}
+    </span>
+  );
+}
+
 function Row({
   message,
   gitShaToCheck,
@@ -65,6 +79,7 @@ function Row({
     version: string;
     url: string;
     service: string;
+    release_tag: string;
     pushDate: number;
     _creationTime: number;
     is_stable: boolean;
@@ -72,7 +87,9 @@ function Row({
   gitShaToCheck: string;
 }) {
   const compareCommits = useAction(api.github.compareCommits);
-  const markReleaseStability = useMutation(api.version_history.markReleaseStability);
+  const markReleaseStability = useMutation(
+    api.version_history.markReleaseStability,
+  );
   const prevDoc = useQuery(api.version_history.prevRev, {
     service: message.service,
     _creationTime: message._creationTime,
@@ -120,7 +137,7 @@ function Row({
   return (
     <div className="flex gap-2 items-center">
       <div className="w-[10%]">{comparison}</div>
-      <div className="flex flex-col w-[45%]">
+      <div className="flex flex-col w-[35%]">
         <span>
           <a
             className="underline text-blue-800 visited:text-purple-800"
@@ -138,6 +155,9 @@ function Row({
           </a>
         </span>
       </div>
+      <div className="w-[10%]">
+        <ReleaseTagBadge tag={message.release_tag} />
+      </div>
       <div className="w-[15%]">{service}</div>
       <div className="w-[20%] flex flex-col">
         <PushTime d={new Date(message.pushDate)} />
@@ -148,7 +168,11 @@ function Row({
           type="checkbox"
           checked={message.is_stable}
           onChange={(e) =>
-            markReleaseStability({ service: message.service, version: message.version, is_stable: e.target.checked })
+            markReleaseStability({
+              service: message.service,
+              version: message.version,
+              is_stable: e.target.checked,
+            })
           }
           title={message.is_stable ? "Stable" : "Unstable"}
         />
@@ -257,7 +281,8 @@ function Rows() {
       <div className="flex flex-col p-4 divide-y gap-2">
         <div className="flex gap-2 items-center font-bold text-sm text-gray-600 pb-2">
           <div className="w-[10%]">Status</div>
-          <div className="w-[45%]">Version</div>
+          <div className="w-[35%]">Version</div>
+          <div className="w-[10%]">Tag</div>
           <div className="w-[15%]">Service</div>
           <div className="w-[20%]">Pushed</div>
           <div className="w-[10%] flex items-center justify-center gap-1">
@@ -268,7 +293,10 @@ function Rows() {
                   <InfoCircledIcon className="h-4 w-4 text-gray-400 hover:text-gray-600" />
                 </TooltipTrigger>
                 <TooltipContent className="max-w-xs">
-                  <p>Versions default to stable and can be manually marked as unstable if there is a bug.</p>
+                  <p>
+                    Versions default to stable and can be manually marked as
+                    unstable if there is a bug.
+                  </p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>


### PR DESCRIPTION
## Summary

This PR adds support for release tags to track different release channels (e.g., "default" and "biz"). It only supports showing the biz and default release tags in the UI right now. We can update this in the future.

## Changes

### Backend Script (`backend_version_history.py`)
- Added `--all-tags` and `--json` flags to the version fetch command (these are now supported)
- Parse JSON output to extract version info for each release tag
- Send release tag along with version data to Convex

### Database Schema (`convex/schema.ts`)
- Added optional `release_tag` field to `version_history` table
- Added new indexes for querying by service and release tag

### Convex Functions (`convex/version_history.ts`)
- Updated `addRow` mutation to accept and store release tags
- Modified `listLatest` query to return latest versions for each tag ("default", "biz")
- Updated `latestStableReleaseForBiz` to filter by "default" release tag
- Updated `markReleaseStability` to mark stability across all release tags for a given version
- Backwards compatibility for supported versions that don't have the `release_tag` field set

### UI (`src/App.tsx`)
- Added `ReleaseTagBadge` component to display release tags with color coding
- Added "Tag" column to the version history table
- Updated layout to accommodate the new column
<img width="1739" height="924" alt="Screenshot 2026-01-27 at 7 36 25 PM" src="https://github.com/user-attachments/assets/e6d25eb8-7a94-4bdc-9e90-ddb1e4ee6837" />