### PR TITLE
Fix SHA checker to compare within same release tag and limit results

### DIFF
--- a/convex/version_history.ts
+++ b/convex/version_history.ts
@@ -86,12 +86,12 @@ export const list = query({
         .query("version_history")
         .withIndex("by_service", (q) => q.eq("service", service))
         .order("desc")
-        .collect();
+        .take(20);
     } else {
       queryResult = await ctx.db
         .query("version_history")
         .order("desc")
-        .collect();
+        .take(20);
     }
     const result = queryResult.map(renderVersionHistoryRow);
     return result;
@@ -179,13 +179,17 @@ export const listLatest = query({
 export const prevRev = query({
   args: {
     service: v.string(),
+    release_tag: v.string(),
     _creationTime: v.number(),
   },
   handler: async (ctx, args) => {
     return ctx.db
       .query("version_history")
-      .withIndex("by_service", (q) =>
-        q.eq("service", args.service).lt("_creationTime", args._creationTime),
+      .withIndex("by_service_and_release_tag", (q) =>
+        q
+          .eq("service", args.service)
+          .eq("release_tag", args.release_tag)
+          .lt("_creationTime", args._creationTime),
       )
       .order("desc")
       .first();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ function Row({
   );
   const prevDoc = useQuery(api.version_history.prevRev, {
     service: message.service,
+    release_tag: message.release_tag,
     _creationTime: message._creationTime,
   });
   const [comparison, setComparison] = useState("");
@@ -284,6 +285,11 @@ function Rows() {
         </>
       )}
       <div>🥱 - It's been over a week</div>
+      {!displayLatestOnly && (
+        <p className="text-sm text-gray-500 ml-4 mt-2">
+          Note: Only the 20 most recently pushed versions are displayed.
+        </p>
+      )}
       <div className="flex flex-col p-4 divide-y gap-2">
         <div className="flex gap-2 items-center font-bold text-sm text-gray-600 pb-2">
           <div className="w-[10%]">Status</div>


### PR DESCRIPTION
## Changes

This PR fixes the SHA checker and improves performance:

1. **Fix prevRev query to filter by release_tag** - The previous revision lookup now filters by both service AND release_tag, ensuring we compare SHAs within the same release tag rather than across all releases.

2. **Limit query results to 20** - Changed `.collect()` to `.take(20)` in the list query to improve performance and reduce data transfer.

3. **Add UI note about limit** - Added a note in the UI indicating that only the 20 most recently pushed versions are displayed (when not in latest-only mode).