### PR TITLE
Reduce biz release lookback from 7 days to 2 days

### DIFF
--- a/convex/version_history.ts
+++ b/convex/version_history.ts
@@ -202,7 +202,7 @@ export const latestStableReleaseForBiz = query({
   },
   returns: v.union(v.null(), v.string()),
   handler: async (ctx, args) => {
-    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const twoDaysAgo = Date.now() - 2 * 24 * 60 * 60 * 1000;
     const release = await ctx.db
       .query("version_history")
       .withIndex("by_service_release_tag_and_is_stable", (q) =>
@@ -210,7 +210,7 @@ export const latestStableReleaseForBiz = query({
           .eq("service", args.service)
           .eq("release_tag", "default")
           .eq("is_stable", true)
-          .lte("_creationTime", sevenDaysAgo),
+          .lte("_creationTime", twoDaysAgo),
       )
       .order("desc")
       .first();


### PR DESCRIPTION
## Summary
- Reduces the `latestStableReleaseForBiz` lookback window from 7 days to 2 days
- This allows biz to receive newer stable versions faster

## Test plan
- [ ] Verify the query returns stable releases that are at least 2 days old instead of 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)