### PR TITLE
Add "types": ["node"] to fix tsconfig on TypeScript 6.0

### DIFF
--- a/convex/tsconfig.json
+++ b/convex/tsconfig.json
@@ -18,7 +18,8 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["./**/*"],
   "exclude": ["./_generated"]


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
